### PR TITLE
Interface name update

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,7 @@
 options:
   collection_path:
     type: string
-    default: "/var/snap/software-inventory-collector/common/output/"
+    default: "/var/snap/software-inventory-collector/common/"
     description: |
       The path where the data should be collected. This can be added to a machine
       where there is a pre-defined storage for the output. Make sure there are

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 # This file populates the Overview on Charmhub.
 # See https://juju.is/docs/sdk/metadata-reference for a checklist and guidance.
 
-name: charm-software-inventory-collector
+name: software-inventory-collector
 display-name: Software Inventory Collector
 
 summary: Charm that deploys Software Inventory Collector snap
@@ -12,7 +12,7 @@ description: |
 
 requires:
   inventory-exporter:
-    interface: inventory-exporter
+    interface: software-inventory
 
 resources:
   collector-snap:


### PR DESCRIPTION
New interface name is used in the release of [software-inventory-exporter charm](https://github.com/canonical/charm-software-inventory-exporter/)