### PR TITLE
fix: tell type checkers that the config options are strings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-#ops >= 1.5.0
-ops @ git+https://github.com/tonyandrewmeyer/operator@fix-config-types-1182
+ops >= 1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-ops >= 1.5.0
+#ops >= 1.5.0
+ops @ git+https://github.com/tonyandrewmeyer/operator@fix-config-types-1182

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,7 +16,7 @@ import logging
 import os
 import subprocess
 from base64 import b64decode
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 import yaml
 from charms.operator_libs_linux.v1 import snap
@@ -135,7 +135,7 @@ class CharmSoftwareInventoryCollectorCharm(CharmBase):
 
         customer = self.config.get("customer")
         site = self.config.get("site")
-        ca_cert = b64decode(self.config.get("juju_ca_cert", "")).decode("UTF-8")
+        ca_cert = b64decode(cast(str, self.config.get("juju_ca_cert", ""))).decode("UTF-8")
 
         config["settings"]["collection_path"] = self.config.get("collection_path")
         config["settings"]["customer"] = customer


### PR DESCRIPTION
ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

This PR simply adds a `typing.cast` call where the config value is loaded and used where the type should be str.